### PR TITLE
Fix use of panels for related attachments, use macros.

### DIFF
--- a/frontend/templates/briefing_detail.html
+++ b/frontend/templates/briefing_detail.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
+{% from 'macros/attachments.html' import audio_attachments, related_attachments %}
 
 {% block page %}
+  <h4 class="light-red">Briefing</h4>
+  <h1>{{ event.title }}</h1>
+  <h5>{{ event.date }}</h5>
+
   <div class="row">
     <div class="col-sm-8">
-      <h4 class="light-red">Briefing</h4>
-      <h1>{{ event.title }}</h1>
-      <h5>{{ event.date }}</h5>
-
-
       {% if (report.summary) %}
         <div class="summary">{{ report.summary|safe }}</div>
       {% endif %}
@@ -17,48 +17,12 @@
         <div>{{ report.body|safe }}</div>
       {% endif %}
 
-      {#    {% if (briefing.presentation) %}#}
-      {#    <h3>Presentation</h3>#}
-      {#    <div>{{ briefing.presentation|safe }}</div>#}
-      {#    {% endif %}#}
     </div>
 
     <div class="col-sm-4">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4>Audio</h4>
-        </div>
-        <div class="panel-body">
-          {% if audio %}
-            <ul class="list-unstyled">
-              {% for item in audio %}
-                <li><a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank"><span class="fa fa-headphones"></span> {{ item.title }}</a></li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="lead text-muted">No audio content</p>
-          {% endif %}
-        </div>
-      </div>
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4>Documents</h4>
-        </div>
-        <div class="panel-body">
-          {% if related_docs %}
-            <ul class="list-unstyled">
-              {% for item in related_docs %}
-                <li><a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank"><span class="fa fa-file"></span> {{ item.title }}</a></li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="lead text-muted">No related documents</p>
-          {% endif %}
-        </div>
-      </div>
+      {{ audio_attachments(audio) }}
+      {{ related_attachments(related_docs) }}
     </div>
-
-
 
   </div>
 {% endblock %}

--- a/frontend/templates/committee_meeting.html
+++ b/frontend/templates/committee_meeting.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% from 'macros/attachments.html' import audio_attachments, related_attachments %}
 
 {% block page %}
   <h3 class="red"><span class="fa fa-comment"></span> Committee meeting</h3>
+  <h1>{{ event.title }}</h1>
 
   <div class="row">
     <div class="col-sm-8 justify-p">
-      <h1>{{ event.title }}</h1>
 
       <h3>
         Committee:
@@ -47,38 +48,8 @@
     </div>
 
     <div class="col-sm-4">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4>Audio</h4>
-        </div>
-        <div class="panel-body">
-          {% if audio %}
-            <ul class="list-unstyled">
-              {% for item in audio %}
-                <li><a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank"><span class="fa fa-headphones"></span> {{ item.title }}</a></li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="lead text-muted">No audio content</p>
-          {% endif %}
-        </div>
-      </div>
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4>Documents</h4>
-        </div>
-        <div class="panel-body">
-          {% if related_docs %}
-            <ul class="list-unstyled">
-              {% for item in related_docs %}
-                <li><a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank"><span class="fa fa-file"></span> {{ item.title }}</a></li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="lead text-muted">No related documents</p>
-          {% endif %}
-        </div>
-      </div>
+      {{ audio_attachments(audio) }}
+      {{ related_attachments(related_docs) }}
     </div>
 
   </div>

--- a/frontend/templates/hansard_detail.html
+++ b/frontend/templates/hansard_detail.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% from 'macros/attachments.html' import audio_attachments, related_attachments %}
 
 {% block page %}
   <h3 class="red"><span class="fa fa-archive"></span> Hansard</h3>
+  <h1>{{ event.title }}</h1>
 
   <div class="row">
     <div class="col-sm-8 justify-p">
-      <h1>{{ event.title }}</h1>
 
       <h3>House:
         {% if event.house %}{{ event.house.name }}
@@ -45,38 +46,8 @@
     </div>
 
     <div class="col-sm-4">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4>Audio</h4>
-        </div>
-        <div class="panel-body">
-          {% if audio %}
-            <ul class="list-unstyled">
-              {% for item in audio %}
-                <li><a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank"><span class="fa fa-headphones"></span> {{ item.title }}</a></li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="lead text-muted">No audio content</p>
-          {% endif %}
-        </div>
-      </div>
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4>Documents</h4>
-        </div>
-        <div class="panel-body">
-          {% if related_docs %}
-            <ul class="list-unstyled">
-              {% for item in related_docs %}
-                <li><a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank"><span class="fa fa-file"></span> {{ item.title }}</a></li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="lead text-muted">No related documents</p>
-          {% endif %}
-        </div>
-      </div>
+      {{ audio_attachments(audio) }}
+      {{ related_attachments(related_docs) }}
     </div>
 
   </div>

--- a/frontend/templates/macros/attachments.html
+++ b/frontend/templates/macros/attachments.html
@@ -1,0 +1,30 @@
+{% macro attachments_panel(title, items, icon) -%}
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title">{{ title }}</h4>
+    </div>
+    <div class="panel-body">
+      {% if items %}
+        <ul class="fa-ul">
+          {% for item in items %}
+          <li>
+            <i class="fa fa-li {{icon}}"></i>
+            <a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank">{{ item.title }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-muted">No related {{ title|lower }}</p>
+      {% endif %}
+    </div>
+  </div>
+{%- endmacro %}
+
+
+{% macro audio_attachments(audio) -%}
+  {{ attachments_panel("Audio", audio, "fa-headphones") }}
+{%- endmacro %}
+
+{% macro related_attachments(related_docs) -%}
+  {{ attachments_panel("Documents", related_docs, "fa-file") }}
+{%- endmacro %}


### PR DESCRIPTION
* Use panel-default now that we have full bootstrap CSS included.
* Use macros to consistently render attached files
* Move page headings above file attachments
* Use fontawesome list icons