### PR TITLE
Use url field for file items from the API.

### DIFF
--- a/frontend/templates/daily_schedule_detail.html
+++ b/frontend/templates/daily_schedule_detail.html
@@ -20,7 +20,7 @@
     {% if file.description %}
     <a href="{{file.url}}"><i class="fa fa-pdf"></i> {{ file.description }}</a>
     {% else %}
-    <a href="{{file.url|file}}"><i class="fa fa-pdf"></i> {{ file.origname }}</a>
+    <a href="{{file.url}}"><i class="fa fa-pdf"></i> {{ file.origname }}</a>
     {% endif %}
     
     {% endfor %}

--- a/frontend/templates/macros/attachments.html
+++ b/frontend/templates/macros/attachments.html
@@ -9,7 +9,7 @@
           {% for item in items %}
           <li>
             <i class="fa fa-li {{icon}}"></i>
-            <a href="{{ STATIC_HOST }}{{ item.file_path }}" target="_blank">{{ item.title }}</a>
+            <a href="{{ item.url }}" target="_blank">{{ item.title }}</a>
           </li>
           {% endfor %}
         </ul>

--- a/frontend/templates/policy_document_detail.html
+++ b/frontend/templates/policy_document_detail.html
@@ -15,9 +15,9 @@
   
 {% for file in policy_document.files %}
   {% if file.description %}
-  <a href="{{file.file_path}}"><i class="fa fa-pdf"></i> {{ file.description }}</a>
+  <a href="{{ file.url }}"><i class="fa fa-pdf"></i> {{ file.description }}</a>
   {% else %}
-  <a href="{{file.file_path|file}}"><i class="fa fa-pdf"></i> {{ file.origname }}</a>
+  <a href="{{ file.url }}"><i class="fa fa-pdf"></i> {{ file.origname }}</a>
   {% endif %}
 {% endfor %}
 

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -75,11 +75,6 @@ def _jinja2_filter_humandate(iso_str):
     return arrow.get(iso_str).humanize()
 
 
-@app.template_filter('file')
-def _jinja2_filter_file(filename):
-    return app.config['STATIC_HOST'] + filename
-
-
 @app.context_processor
 def pagination_processor():
     def pagination(page_count, current_page, per_page, url):
@@ -415,8 +410,7 @@ def committee_meeting(event_id):
         report=report,
         audio=audio,
         related_docs=related_docs,
-        admin_edit_url=admin_url('committee_meeting', event_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('committee_meeting', event_id))
 
 
 @app.route('/tabled-committee-reports/')
@@ -468,9 +462,7 @@ def tabled_committee_report(tabled_committee_report_id):
     return render_template(
         'tabled_committee_report_detail.html',
         tabled_committee_report=tabled_committee_report,
-        admin_edit_url=admin_url('tabled_report', tabled_committee_report_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
-
+        admin_edit_url=admin_url('tabled_report', tabled_committee_report_id))
 
 @app.route('/calls-for-comments/')
 @app.route('/calls-for-comments/<int:page>/')
@@ -521,8 +513,7 @@ def call_for_comment(call_for_comment_id):
     return render_template(
         'call_for_comment_detail.html',
         call_for_comment=call_for_comment,
-        admin_edit_url=admin_url('call_for_comment', call_for_comment_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('call_for_comment', call_for_comment_id))
 
 
 @app.route('/policy-documents/')
@@ -561,8 +552,7 @@ def policy_document(policy_document_id):
     return render_template(
         'policy_document_detail.html',
         policy_document=policy_document,
-        admin_edit_url=admin_url('policy', policy_document_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('policy', policy_document_id))
 
 
 @app.route('/gazettes/')
@@ -601,8 +591,7 @@ def gazette(gazette_id):
     return render_template(
         'gazette_detail.html',
         gazette=gazette,
-        admin_edit_url=admin_url('gazette', gazette_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('gazette', gazette_id))
 
 
 @app.route('/members/')
@@ -637,8 +626,7 @@ def member(member_id):
     return render_template(
         'member_detail.html',
         member=member,
-        admin_edit_url=admin_url('member', member_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('member', member_id))
 
 
 @app.route('/hansard/<int:event_id>')
@@ -662,8 +650,7 @@ def hansard(event_id):
         report=report,
         audio=audio,
         related_docs=related_docs,
-        admin_edit_url=admin_url('hansard', event_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('hansard', event_id))
 
 
 @app.route('/hansards/')
@@ -713,8 +700,7 @@ def briefing(event_id):
         report=report,
         audio=audio,
         related_docs=related_docs,
-        admin_edit_url=admin_url('briefing', event_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('briefing', event_id))
 
 
 @app.route('/briefings/')
@@ -750,8 +736,7 @@ def daily_schedule(daily_schedule_id):
     return render_template(
         'daily_schedule_detail.html',
         daily_schedule=daily_schedule,
-        admin_edit_url=admin_url('schedule', daily_schedule_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('schedule', daily_schedule_id))
 
 
 @app.route('/daily_schedules/')
@@ -786,8 +771,7 @@ def question_reply(question_reply_id):
     return render_template(
         'question_reply_detail.html',
         question_reply=question_reply,
-        admin_edit_url=admin_url('question', question_reply_id),
-        STATIC_HOST=app.config['STATIC_HOST'])
+        admin_edit_url=admin_url('question', question_reply_id))
 
 
 @app.route('/question_replies/')
@@ -886,7 +870,6 @@ def search(page=0):
     committees = committee_list['results']
     return render_template(
         'search.html',
-        STATIC_HOST=app.config['STATIC_HOST'],
         q=q,
         results=result,
         count=count,


### PR DESCRIPTION
This means others who consume the API can also find the links
to the files, and simplifies our handling of file attachments.