### PR TITLE
Use mandrill subaccounts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,5 +18,14 @@ with open('config/%s/logging.yaml' % env) as f:
     import yaml
     logging.config.dictConfig(yaml.load(f))
 
+
+# override flask mail's send operation to inject some customer headers
+original_send = mail.send
+def send_email_with_subaccount(message):
+    message.extra_headers = {'X-MC-Subaccount': app.config['MANDRILL_TRANSACTIONAL_SUBACCOUNT']}
+    original_send(message)
+app.extensions.get('mail').send = send_email_with_subaccount
+
+
 import views
 import admin

--- a/backend/email_alerts.py
+++ b/backend/email_alerts.py
@@ -74,7 +74,8 @@ class EmailAlertForm(Form):
     template_id = HiddenField('template_id', [validators.Required()])
     previewed = HiddenField('previewed', default='0')
     subject = StringField('Subject', [validators.Required()])
-    from_line = EmailField('From', [validators.Required()], default='"PMG Notifications " <alerts@pmg.org.za>')
+    # This MUST be an email address, the Mandrill API doesn't allow us to do names and emails in one field
+    from_email = EmailField('From address', [validators.Required()], default='alerts@pmg.org.za')
     body = TextAreaField('Content of the alert')
 
     # recipient options
@@ -111,6 +112,7 @@ class EmailAlertForm(Form):
         msg = {
             "html": self.message.html,
             "subject": self.message.subject,
+            "from_name": "PMG Notifications",
             "from_email": self.message.sender,
             "to": recipients,
             "merge_vars": merge_vars,
@@ -133,7 +135,7 @@ class EmailAlertForm(Form):
 
         self.message = Message(
                 subject=self.subject.data,
-                sender=self.from_line.data,
+                sender=self.from_email.data,
                 html=self.body.data)
 
     def get_recipient_users(self):

--- a/backend/email_alerts.py
+++ b/backend/email_alerts.py
@@ -117,6 +117,7 @@ class EmailAlertForm(Form):
             "track_opens": True,
             "track_clicks": True,
             "preserve_recipients": False,
+            "subaccount": app.config['MANDRILL_ALERTS_SUBACCOUNT'],
         }
 
         log.info("Email will be sent to %d recipients." % len(recipients))

--- a/backend/static/javascript/email_alerts.js
+++ b/backend/static/javascript/email_alerts.js
@@ -4,15 +4,18 @@ $(function() {
 
     self.init = function() {
       self.form = $('#new_alert_form');
-      self.form.find('.btn.preview').on('click', self.preview);
+      self.form.on('submit', function(e) {
+        if (self.form.find('[name=previewed]').val() != "1") {
+          e.preventDefault();
+          self.preview();
+        }
+      });
       $('.btn.send').on('click', self.send);
 
       self.editor = CKEDITOR.replace('body');
     };
 
-    self.preview = function(e) {
-      e.preventDefault();
-
+    self.preview = function() {
       $('.btn.preview').prop('disabled', true);
 
       self.editor.updateElement();

--- a/backend/templates/admin/alerts/new.html
+++ b/backend/templates/admin/alerts/new.html
@@ -19,8 +19,8 @@
   <form class="form-horizontal" action="{{ url_for('alerts.new') }}" method="POST" id="new_alert_form" data-confirm="Lots of people will read this email. Have you checked the details?">
     {{ form.hidden_tag() }}
 
-    {{ render_field_with_errors(form.from_line) }}
-    {{ render_field_with_errors(form.subject) }}
+    {{ render_field_with_errors(form.from_email, required=True) }}
+    {{ render_field_with_errors(form.subject, required=True) }}
 
     <div class="form-group">
       {{ form.body.label(class_='control-label col-sm-2') }}
@@ -85,7 +85,7 @@
     <hr>
 
     <div class="text-center">
-      <button type="button" class="btn btn-success preview">Preview &amp; Send email</button>
+      <button type="submit" class="btn btn-success preview">Preview &amp; Send email</button>
     </div>
   </form>
 

--- a/config/development/config.py
+++ b/config/development/config.py
@@ -35,6 +35,8 @@ ALLOWED_EXTENSIONS = set(
 
 # Mandrill
 MANDRILL_API_KEY = env.get('MAIL_PASSWORD')
+MANDRILL_TRANSACTIONAL_SUBACCOUNT = 'transactional'
+MANDRILL_ALERTS_SUBACCOUNT = 'alerts'
 
 # Flask-Mail
 MAIL_SERVER = 'smtp.mandrillapp.com'

--- a/config/production/config.py
+++ b/config/production/config.py
@@ -33,6 +33,8 @@ ALLOWED_EXTENSIONS = set(
 
 # Mandrill
 MANDRILL_API_KEY = env.get('MAIL_PASSWORD')
+MANDRILL_TRANSACTIONAL_SUBACCOUNT = 'transactional'
+MANDRILL_ALERTS_SUBACCOUNT = 'alerts'
 
 # Flask-Mail
 MAIL_SERVER = 'smtp.mandrillapp.com'


### PR DESCRIPTION
Separate out transactional email from alerts, so they have different reputations.