### PR TITLE
Restart processes gracefully with SIGHUP

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -23,8 +23,8 @@ def index_search():
 
 
 def restart():
-    sudo("supervisorctl restart pmg_cms")
-    sudo("supervisorctl restart pmg_frontend")
+    sudo("supervisorctl pid pmg_cms | xargs kill -HUP")
+    sudo("supervisorctl pid pmg_frontend | xargs kill -HUP")
     return
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ PyYAML==3.11
 SQLAlchemy==0.8.2
 WTForms==1.0.5
 Werkzeug==0.9.6
+XlsxWriter==0.6.6
 alembic==0.7.4
 argparse==1.2.1
 arrow==0.4.4
@@ -25,7 +26,7 @@ cssselect==0.9.1
 docopt==0.4.0
 ecdsa==0.11
 enum34==1.0.4
-gunicorn==19.1.1
+gunicorn==19.2.1
 inflection==0.2.1
 itsdangerous==0.24
 lxml==3.4.1
@@ -45,4 +46,3 @@ simplejson==3.6.5
 six==1.8.0
 webassets==0.10.1
 wsgiref==0.1.2
-xlsxwriter

--- a/run-cms-production.sh
+++ b/run-cms-production.sh
@@ -4,4 +4,16 @@ set -e
 source env/bin/activate
 source production-env.sh
 
+# catch SIGHUP and send to children, this tells gunicorn to restart gracefully
+trap sighup 1
+
+sighup() {
+  kill -HUP $child
+}
+
 /var/www/pmg-cms/env/bin/newrelic-admin run-program /var/www/pmg-cms/env/bin/gunicorn -w 4 backend.app:app --bind 127.0.0.1:5005 --timeout 600 --log-file -
+child=$!
+
+while true; do
+  wait $child
+done

--- a/run-cms-production.sh
+++ b/run-cms-production.sh
@@ -11,7 +11,7 @@ sighup() {
   kill -HUP $child
 }
 
-/var/www/pmg-cms/env/bin/newrelic-admin run-program /var/www/pmg-cms/env/bin/gunicorn -w 4 backend.app:app --bind 127.0.0.1:5005 --timeout 600 --log-file -
+/var/www/pmg-cms/env/bin/newrelic-admin run-program /var/www/pmg-cms/env/bin/gunicorn -w 4 backend.app:app --bind 127.0.0.1:5005 --timeout 600 --max-requests 20000 --max-requests-jitter 1000 --log-file -
 child=$!
 
 while true; do

--- a/run-frontend-production.sh
+++ b/run-frontend-production.sh
@@ -11,7 +11,7 @@ sighup() {
   kill -HUP $child
 }
 
-/var/www/pmg-cms/env/bin/newrelic-admin run-program /var/www/pmg-cms/env/bin/gunicorn -w 4 frontend:app --bind 127.0.0.1:5006 --timeout 30 --log-file -
+/var/www/pmg-cms/env/bin/newrelic-admin run-program /var/www/pmg-cms/env/bin/gunicorn -w 4 frontend:app --bind 127.0.0.1:5006 --timeout 30 --max-requests 20000 --max-requests-jitter 1000 --log-file -
 child=$!
 
 while true; do

--- a/run-frontend-production.sh
+++ b/run-frontend-production.sh
@@ -4,4 +4,16 @@ set -e
 source env/bin/activate
 source production-env.sh
 
+# catch SIGHUP and send to children, this tells gunicorn to restart gracefully
+trap sighup 1
+
+sighup() {
+  kill -HUP $child
+}
+
 /var/www/pmg-cms/env/bin/newrelic-admin run-program /var/www/pmg-cms/env/bin/gunicorn -w 4 frontend:app --bind 127.0.0.1:5006 --timeout 30 --log-file -
+child=$!
+
+while true; do
+  wait $child
+done


### PR DESCRIPTION
We need to tell the bash processes explicitly to send the HUP to their
children, otherwise they quit when they receive HUP.

For https://trello.com/c/GWx1g1MM/324-user-should-see-less-bad-gateway-errors