### PR TITLE
Fix toggling of collapse elements.

### DIFF
--- a/frontend/static/resources/javascript/pmg.js
+++ b/frontend/static/resources/javascript/pmg.js
@@ -1,10 +1,12 @@
 $(function() {
 	$(".collapse-link").on("click", function(e) {
 		e.preventDefault();
-		$(this).next(".collapse").toggle(400, function(test) {
+		$(this).next(".collapse").toggle(300, function(test) {
 			if ($(this).css("display") == "block") {
+				$(this).addClass("in");
 				$(this).prev(".collapse-link").find(".fa").removeClass("fa-caret-right").addClass("fa-caret-down");
 			} else {
+				$(this).removeClass("in");
 				$(this).prev(".collapse-link").find(".fa").removeClass("fa-caret-down").addClass("fa-caret-right");
 			}
 		});


### PR DESCRIPTION
Currently visible collapse elements must have the 'in' attribute. We could make this cleaner using bootstrap events, but it works for now.

Fixes https://trello.com/c/dxEdWG5A/328-committee-about-content-is-not-visible