### PR TITLE
Specify naming constraints for SQLAlchemy so that alembic just works

### DIFF
--- a/pmg/__init__.py
+++ b/pmg/__init__.py
@@ -20,6 +20,15 @@ with open('config/%s/logging.yaml' % env) as f:
 
 
 db = SQLAlchemy(app)
+# Define naming constraints so that Alembic just works
+# See http://docs.sqlalchemy.org/en/rel_0_9/core/constraints.html#constraint-naming-conventions
+db.metadata.naming_convention = {
+    "ix": 'ix_%(column_0_label)s',
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s"
+}
 migrate = Migrate(app, db, transaction_per_migration=True)
 csrf = CsrfProtect(app)
 mail = Mail(app)

--- a/pmg/models/resources.py
+++ b/pmg/models/resources.py
@@ -113,7 +113,7 @@ class BillStatus(db.Model):
 
 class Bill(ApiResource, db.Model):
     __tablename__ = "bill"
-    __table_args__ = (db.UniqueConstraint('number', 'year', 'type_id'), {})
+    __table_args__ = (db.UniqueConstraint('number', 'year', 'type_id', name='bill_number_year_type_id_key'), {})
 
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(250), nullable=False)


### PR DESCRIPTION
Without this, Alembic doesn't generate names in a way that allows both
the upgrade and downgrade paths to work without manual changes.

This specifies naming constraints that match what SQLAlchemy has
used up until now.

This fixes the issue in #67 that meant that that migration couldn't be run backwards.

@xybrnet