### PR TITLE
FIX search alerts to improve results, exclude daily schedules

### DIFF
--- a/pmg/models/emails.py
+++ b/pmg/models/emails.py
@@ -8,7 +8,6 @@ import mandrill
 from flask import render_template, url_for
 
 from pmg import db, app
-from pmg.models.resources import DailySchedule
 
 
 log = logging.getLogger(__name__)
@@ -92,8 +91,7 @@ class SavedSearch(db.Model):
         from pmg.search import Search
 
         # find hits updated since the last time we did this search
-        search = Search().search(self.search, document_type=self.content_type, committee=self.committee_id,
-                                 exclude_document_types=[DailySchedule.resource_content_type])
+        search = Search().search(self.search, document_type=self.content_type, committee=self.committee_id)
 
         if 'hits' not in search:
             log.warn("Error doing search for %s: %s" % (self, search))

--- a/pmg/search.py
+++ b/pmg/search.py
@@ -137,7 +137,7 @@ class Search:
         }
         self.es.put_mapping(self.index_name, data_type, mapping)
 
-    def build_filters(self, start_date, end_date, document_type, committee, updated_since):
+    def build_filters(self, start_date, end_date, document_type, committee, updated_since, exclude_document_types):
         filters = {}
 
         if start_date and end_date:
@@ -160,6 +160,13 @@ class Search:
                 "term": {"_type": document_type},
             }
 
+        if exclude_document_types:
+            filters["document_type_excludes"] = {
+                "not": {
+                    "or": [{"term": {"_type": dt}} for dt in exclude_document_types],
+                }
+            }
+
         if updated_since:
             filters["updated_at"] = {
                 "range": {
@@ -172,8 +179,8 @@ class Search:
         return filters
 
     def search(self, query, size=10, es_from=0, start_date=False, end_date=False, document_type=False, committee=False,
-               updated_since=None):
-        filters = self.build_filters(start_date, end_date, document_type, committee, updated_since)
+               updated_since=None, exclude_document_types=None):
+        filters = self.build_filters(start_date, end_date, document_type, committee, updated_since, exclude_document_types)
 
         q = {
             # We do two queries, one is a general term query across the fields,

--- a/pmg/search.py
+++ b/pmg/search.py
@@ -115,17 +115,19 @@ class Search:
                 "title": {
                     "type": "string",
                     "analyzer": "english",
-                    "index_options": "offsets"
+                    "index_options": "offsets",
                 },
                 "fulltext": {
                     "type": "string",
                     "analyzer": "english",
-                    "index_options": "offsets"
+                    "index_options": "offsets",
+                    "term_vector": "with_positions_offsets",
                 },
                 "description": {
                     "type": "string",
                     "analyzer": "english",
-                    "index_options": "offsets"
+                    "index_options": "offsets",
+                    "term_vector": "with_positions_offsets",
                 },
                 "number": {
                     "type": "integer",
@@ -245,7 +247,6 @@ class Search:
                 "pre_tags": ["<mark>"],
                 "post_tags": ["</mark>"],
                 "order": "score",
-                "fragment_size": 80,
                 "no_match_size": 0,
                 "fields": {
                     "title": {

--- a/pmg/templates/saved_search_alert.html
+++ b/pmg/templates/saved_search_alert.html
@@ -24,3 +24,7 @@ if search.content_type %} in {{ search.friendly_content_type }}{% endif %}:
   </li>
 {% endfor %}
 </ul>
+
+<p>
+Click here to <a href="{{ url_for('email_alerts', _external=True) }}">manage your email alerts</a>.
+</p>


### PR DESCRIPTION
Filter recent results locally so that elasticsearch still returns
the top results. Otherwise, we only compare NEW results against
each other, which could have really poor matches.

@xybrnet 