### PR TITLE
FIX alerts page for anonymous users

### DIFF
--- a/pmg/static/resources/javascript/users.js
+++ b/pmg/static/resources/javascript/users.js
@@ -1,86 +1,89 @@
 $(function() {
-  // set select-all value on page load
-  $(".select-all").each(function(){
-    var select_all = $(this);
-    var all_checked = true;
-    var parent_list = select_all.closest('ul');
-    parent_list.find(':checkbox.select-committee').each(function(){
-      var tmp_checkbox = $(this);
-      if(!tmp_checkbox.is(':checked'))
-      {
-        all_checked = false;
-        return false; // break out of 'each' loop
-      }
-    });
-    if(all_checked)
-      select_all.prop("checked", true);
-  });
+  if ($('body').hasClass('email_alerts')) {
+    // disable checkboxes when not logged in
+    $('body.not-logged-in input[type=checkbox]').prop('disabled', true);
 
-  // toggle list of checkboxes with select-all
-  $(".select-all").each(function(){
-    var select_all = $(this);
-    select_all.on('change', function(){
+    // set select-all value on page load
+    $(".select-all").each(function(){
+      var select_all = $(this);
+      var all_checked = true;
       var parent_list = select_all.closest('ul');
-      if (select_all.is(':checked'))
-      {
-        // check all other boxes in the list
-        parent_list.find(':checkbox.select-committee').prop('checked', true);
-      }
-      else
-      {
-        // un-check all other boxes in the list
-        parent_list.find(':checkbox.select-committee').prop('checked', false);
-      }
+      parent_list.find(':checkbox.select-committee').each(function(){
+        var tmp_checkbox = $(this);
+        if(!tmp_checkbox.is(':checked'))
+        {
+          all_checked = false;
+          return false; // break out of 'each' loop
+        }
+      });
+      if(all_checked)
+        select_all.prop("checked", true);
     });
-  });
 
-  $("input").on('change', function(){
-    var input = $(this),
-        checked = input.prop('checked');
-
-    if (input.prop('id') === 'select-daily-schedule' ) {
-      $('form#email-alerts #select-daily-schedule').prop('checked', checked);
-    }
-      if (input.hasClass('select-all')) {
-        input.closest('.checkbox').siblings('.checkbox').find('.status-indicator').addClass('hidden');
-      }
-      else
-      {
-        input.siblings('.status-indicator').addClass('hidden');
-      }
-
-
-    $.post(
-      '/email-alerts/',
-      $( "#email-alerts" ).serialize()
-    ).done(function(resp) {
-      if (input.hasClass('select-all')) {
-        input.closest('.checkbox').siblings('.checkbox').find('.status-indicator').removeClass('hidden');
-      }
-      else
-      {
-        input.siblings('.status-indicator').removeClass('hidden');
-      }
-
+    // toggle list of checkboxes with select-all
+    $(".select-all").each(function(){
+      var select_all = $(this);
+      select_all.on('change', function(){
+        var parent_list = select_all.closest('ul');
+        if (select_all.is(':checked'))
+        {
+          // check all other boxes in the list
+          parent_list.find(':checkbox.select-committee').prop('checked', true);
+        }
+        else
+        {
+          // un-check all other boxes in the list
+          parent_list.find(':checkbox.select-committee').prop('checked', false);
+        }
+      });
     });
-  });
 
-  $(".remove-search-alert").on("click", function(e) {
+    $("input").on('change', function(){
+      var input = $(this),
+          checked = input.prop('checked');
 
-    var btn = $(this),
-        id = btn.data('id') || "",
-        group = btn.closest('.grouped-search-alerts');
-
-    $.post(
-      '/user/saved-search/' + id + '/delete'
-    ).done(function(resp) {
-      btn.parents('.search-alert').remove();
-      if (group.children('.search-alert').length === 0) {
-        group.remove();
+      if (input.prop('id') === 'select-daily-schedule' ) {
+        $('form#email-alerts #select-daily-schedule').prop('checked', checked);
       }
-      ga('send', 'event', 'user', 'remove-search-alert');
-    });
-  });
+        if (input.hasClass('select-all')) {
+          input.closest('.checkbox').siblings('.checkbox').find('.status-indicator').addClass('hidden');
+        }
+        else
+        {
+          input.siblings('.status-indicator').addClass('hidden');
+        }
 
+
+      $.post(
+        '/email-alerts/',
+        $( "#email-alerts" ).serialize()
+      ).done(function(resp) {
+        if (input.hasClass('select-all')) {
+          input.closest('.checkbox').siblings('.checkbox').find('.status-indicator').removeClass('hidden');
+        }
+        else
+        {
+          input.siblings('.status-indicator').removeClass('hidden');
+        }
+
+      });
+    });
+
+    $(".remove-search-alert").on("click", function(e) {
+
+      var btn = $(this),
+          id = btn.data('id') || "",
+          group = btn.closest('.grouped-search-alerts');
+
+      $.post(
+        '/user/saved-search/' + id + '/delete'
+      ).done(function(resp) {
+        btn.parents('.search-alert').remove();
+        if (group.children('.search-alert').length === 0) {
+          group.remove();
+        }
+        ga('send', 'event', 'user', 'remove-search-alert');
+      });
+    });
+  }
 });
-

--- a/pmg/templates/layout.html
+++ b/pmg/templates/layout.html
@@ -33,7 +33,7 @@
   {% block head_meta %}{% endblock %}
 </head>
 
-<body class="{{ request.endpoint }}">
+<body class="{{ request.endpoint }} {% if current_user.is_authenticated() %}logged-in{% else %}not-logged-in{% endif %}">
   <div id="wrapper">
     {% block content %}
     {% endblock content %}

--- a/pmg/templates/user_management/email_alerts.html
+++ b/pmg/templates/user_management/email_alerts.html
@@ -5,41 +5,59 @@
 {% block page %}
   <h1>Free Email Alerts</h1>
 
-  <p class="lead">Which email alerts should we send to you?</p>
-
   {% if not current_user.is_authenticated() %}
-    <p>To receive free email alerts, <a href="{{ url_for('register') }}">sign up with PMG for free</a> or <a href="{{ url_for('login') }}">log in</a>.</p>
-  {% else %}
-    {% if after_signup %}
-      <a href="{{ next_url }}" class="btn btn-default">I'll do this later</a>
-    {% endif %}
-    <ul class="list-unstyled daily-schedule">
-      <li class="checkbox">
-        <label>
-          <input type="checkbox" id="select-daily-schedule" name="subscribe_daily_schedule" {% if current_user.subscribe_daily_schedule %} checked{% endif %} value="1">
-          Receive a daily schedule for Parliament
-          <span class="status-indicator hidden"><i class="fa fa-check"></i></span>
-        </label>
-      </li>
-    </ul>
+    <div class="row">
+      <div class="col-sm-5 col-sm-offset-4">
+        <div class="alert alert-info">
+          <h4>Sign up with PMG</h4>
+          <p>To receive free email alerts you need a PMG account.</p>
+          <br>
 
-    <div>
-      <!-- Nav tabs -->
-      <ul class="nav nav-tabs" role="tablist">
-        <li role="presentation" class="active"><a href="#committee-alerts" aria-controls="commitee-alerts" role="tab" data-toggle="tab">Committee Alerts</a></li>
-        <li role="presentation"><a href="#search-alerts" aria-controls="search-alerts" role="tab" data-toggle="tab">Search Alerts</a></li>
-      </ul>
-
-      <!-- Tab panes -->
-      <div class="tab-content">
-        <div role="tabpanel" class="tab-pane active" id="committee-alerts">
-          {% include 'user_management/committee_alerts.html' %}
-        </div>
-        <div role="tabpanel" class="tab-pane" id="search-alerts">
-          {% include 'user_management/search_alerts.html' %}
+          <div class="row">
+            <div class="col-xs-6">
+              <a class="form-control btn btn-primary" href="{{ url_for('security.login', next=request.full_path) }}">Log in</a>
+            </div>
+            <div class="col-xs-6">
+              <a class="form-control btn btn-primary" href="{{ url_for('security.register', next=request.full_path) }}">Sign up</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-
   {% endif %}
+
+  <p class="lead">Which email alerts should we send to you?</p>
+
+  {% if current_user.is_authenticated() and after_signup %}
+    <a href="{{ next_url }}" class="btn btn-default">I'll do this later</a>
+  {% endif %}
+
+  <ul class="list-unstyled daily-schedule">
+    <li class="checkbox">
+      <label>
+        <input type="checkbox" id="select-daily-schedule" name="subscribe_daily_schedule" {% if current_user.subscribe_daily_schedule %} checked{% endif %} value="1">
+        Receive a daily schedule for Parliament
+        <span class="status-indicator hidden"><i class="fa fa-check"></i></span>
+      </label>
+    </li>
+  </ul>
+
+  <div>
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active"><a href="#committee-alerts" aria-controls="commitee-alerts" role="tab" data-toggle="tab">Committee Alerts</a></li>
+      <li role="presentation"><a href="#search-alerts" aria-controls="search-alerts" role="tab" data-toggle="tab">Search Alerts</a></li>
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <div role="tabpanel" class="tab-pane active" id="committee-alerts">
+        {% include 'user_management/committee_alerts.html' %}
+      </div>
+      <div role="tabpanel" class="tab-pane" id="search-alerts">
+        {% include 'user_management/search_alerts.html' %}
+      </div>
+    </div>
+  </div>
+
 {% endblock page %}

--- a/pmg/user_management.py
+++ b/pmg/user_management.py
@@ -125,8 +125,9 @@ def email_alerts():
         subscriptions = set()
 
     saved_searches = defaultdict(list)
-    for ss in current_user.saved_searches:
-        saved_searches[ss.search].append(ss)
+    if current_user.is_authenticated():
+        for ss in current_user.saved_searches:
+            saved_searches[ss.search].append(ss)
 
     return render_template(
         'user_management/email_alerts.html',

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -779,7 +779,10 @@ def docs(path, dir=''):
         dir = dir + '/'
 
     # report to google analytics
-    utils.track_pageview()
+    try:
+        utils.track_pageview()
+    except StandardError as e:
+        logger.error("Error tracking pageview: %s" % e.message, exc_info=e)
 
     return redirect(app.config['STATIC_HOST'] + dir + path)
 

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -184,8 +184,8 @@ def committee_detail(committee_id):
     committee = load_from_api('committee', committee_id)
 
     params = {
-      'filter[committee_id]': committee_id,
-      'per_page': 5
+        'filter[committee_id]': committee_id,
+        'per_page': 5
     }
     recent_questions = load_from_api(
         'minister-questions-combined',
@@ -801,4 +801,3 @@ def correct_this_page():
         flash('Thanks for your feedback.', 'info')
 
     return redirect(request.form.get('url', '/'))
-


### PR DESCRIPTION
Show them the page so that they can see what they'll get,
but disable the controls and show a login/register box.

Also stop the form controls from firing on pages that aren't
the email alert page.

@xybrnet 