### PR TITLE
Adjust elasticsearch to favour recent results.

### DIFF
--- a/pmg/search.py
+++ b/pmg/search.py
@@ -218,11 +218,11 @@ class Search:
                 "query": q,
                 "gauss": {
                     "date": {
-                        # Scores must decay, starting at docs from 5 days ago
+                        # Scores must decay, starting at docs from 7 days ago
                         # such that docs 30 days ago are at 0.6.
                         # See https://www.elastic.co/blog/found-function-scoring
-                        "scale": "30d",
                         "offset": "7d",
+                        "scale": "30d",
                         "decay": 0.6,
                     }
                 }

--- a/pmg/search.py
+++ b/pmg/search.py
@@ -210,6 +210,22 @@ class Search:
                         "type": "phrase"
                     },
                 }
+            },
+        }
+
+        q = {
+            "function_score": {
+                "query": q,
+                "gauss": {
+                    "date": {
+                        # Scores must decay, starting at docs from 5 days ago
+                        # such that docs 30 days ago are at 0.6.
+                        # See https://www.elastic.co/blog/found-function-scoring
+                        "scale": "30d",
+                        "offset": "7d",
+                        "decay": 0.6,
+                    }
+                }
             }
         }
 
@@ -322,7 +338,6 @@ class Transforms:
         Member: {
             "title": "name",
             "description": "bio",
-            "date": "start_date",
         },
         Bill: {
             "title": "title",


### PR DESCRIPTION
This applies a gaussian decay function to the
scores, starting when docs are 5 days old,
such that at 30 days old scores are 60% (0.6)
of what they'd normally be.

This will ensure we favour recent results without
biasing too heavily.

This will help to ensure that more recent, revelant
docs show up in search alerts, otherwise we
tend to have older docs in the top 20 results (simply
because there are more of them).

Fixes #54.

@xybrnet 