### PR TITLE
Support "quoted phrase" searches

### DIFF
--- a/pmg/api.py
+++ b/pmg/api.py
@@ -209,14 +209,18 @@ def search():
     except ValueError:
         per_page = app.config['SEARCH_RESULTS_PER_PAGE']
 
-    searchresult = Search().search(
-        q,
-        per_page,
-        page * per_page,
-        document_type=request.args.get('type'),
-        start_date=request.args.get('start_date'),
-        end_date=request.args.get('end_date'),
-        committee=request.args.get('committee'))
+    try:
+        searchresult = Search().search(
+            q,
+            per_page,
+            page * per_page,
+            document_type=request.args.get('type'),
+            start_date=request.args.get('start_date'),
+            end_date=request.args.get('end_date'),
+            committee=request.args.get('committee'))
+    except ValueError:
+        # no query passed in
+        raise ApiException(422, "No search term given.")
 
     aggs = searchresult["aggregations"]
 

--- a/pmg/api_client.py
+++ b/pmg/api_client.py
@@ -2,7 +2,7 @@ import logging
 import requests
 import urllib
 
-from flask import flash, session, abort, redirect, url_for, request
+from flask import flash, session, abort, redirect, url_for, request, render_template
 from werkzeug.exceptions import HTTPException
 from flask.ext.security import current_user
 


### PR DESCRIPTION
We pick out quoted phrases and tell ES that they're required.
For non-phrase terms, we prefer if they're close together.

We update the highlighting to try to always highlight phrases.
It's a bit of a black art.

Finally, handle phrase searches that result in nothing, eg "   "

@xybrnet 