### PR TITLE
Check if member is assigned to a party, return None if not

### DIFF
--- a/pmg/api.py
+++ b/pmg/api.py
@@ -481,8 +481,8 @@ def committee_meeting_attendance_summary():
             member = {'id': member_id}
             if m:
                 member['name'] = m.name
-                member['party_id'] = m.party.id
-                member['party_name'] = m.party.name
+                member['party_id'] = m.party.id if m.party else None
+                member['party_name'] = m.party.name if m.party else None
                 member['pa_url'] = m.pa_url
 
             summaries.append({


### PR DESCRIPTION
The API endpoint was failing if no party is assigned to a member.
This checks if it is the case, and returns None is so.

@longhotsummer 