### PR TITLE
Use api-internal.pmg.org.za

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -97,11 +97,11 @@ SHARPSPRING_API_SECRET = env.get('SHARPSPRING_API_SECRET')
 
 if DEBUG:
     SERVER_NAME = 'pmg.dev:5000'
-    API_HOST = "http://api.pmg.dev:5000/"
+    API_URL = "http://api.pmg.dev:5000/"
     FRONTEND_HOST = "http://pmg.dev:5000/"
     SESSION_COOKIE_DOMAIN = "pmg.dev"
 else:
     SERVER_NAME = 'pmg.org.za'
-    API_HOST = "https://api.pmg.org.za/"
+    API_URL = "https://api-internal.pmg.org.za/"
     FRONTEND_HOST = "https://pmg.org.za/"
     SESSION_COOKIE_DOMAIN = "pmg.org.za"

--- a/config/config.py
+++ b/config/config.py
@@ -102,6 +102,8 @@ if DEBUG:
     SESSION_COOKIE_DOMAIN = "pmg.dev"
 else:
     SERVER_NAME = 'pmg.org.za'
+    # Use the EC2-internal API endpoint, which doesn't trombone through the EC2
+    # firewall and back in again, saving us money and msecs
     API_URL = "https://api-internal.pmg.org.za/"
     FRONTEND_HOST = "https://pmg.org.za/"
     SESSION_COOKIE_DOMAIN = "pmg.org.za"

--- a/pmg/__init__.py
+++ b/pmg/__init__.py
@@ -145,6 +145,10 @@ import admin
 
 from pmg.api.v1 import api as api_v1
 app.register_blueprint(api_v1, subdomain='api')
+# api-internal.pmg.org.za resolves to the internal IP of the API host
+app.register_blueprint(api_v1, subdomain='api-internal')
 
 from pmg.api.v2 import api as api_v2
 app.register_blueprint(api_v2, subdomain='api', url_prefix='/v2')
+# api-internal.pmg.org.za resolves to the internal IP of the API host
+app.register_blueprint(api_v2, subdomain='api-internal', url_prefix='/v2')

--- a/pmg/api/client.py
+++ b/pmg/api/client.py
@@ -8,7 +8,7 @@ from flask.ext.security import current_user
 
 from pmg import app
 
-API_HOST = app.config['API_HOST']
+API_URL = app.config['API_URL']
 # timeout connecting and reading from remote host
 TIMEOUTS = (3.05, 10)
 
@@ -76,7 +76,7 @@ def load_from_api(resource_name, resource_id=None, page=None, return_everything=
         headers = {'Authentication-Token': current_user.get_auth_token()}
 
     try:
-        response = requests.get(API_HOST + query_str, headers=headers, params=params, timeout=TIMEOUTS)
+        response = requests.get(API_URL + query_str, headers=headers, params=params, timeout=TIMEOUTS)
 
         if response.status_code == 404:
             abort(404)

--- a/pmg/api/client.py
+++ b/pmg/api/client.py
@@ -105,37 +105,3 @@ def load_from_api(resource_name, resource_id=None, page=None, return_everything=
     except requests.ConnectionError as e:
         logger.error("Error connecting to backend service: %s" % e, exc_info=e)
         flash(u'Error connecting to backend service.', 'danger')
-
-
-def send_to_api(endpoint, data=None):
-
-    query_str = endpoint + "/"
-
-    headers = {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-    }
-    # add auth header
-    if session and session.get('api_key'):
-        headers['Authentication-Token'] = session.get('api_key')
-    try:
-        response = requests.post(
-            API_HOST +
-            query_str,
-            headers=headers,
-            data=data,
-            timeout=TIMEOUTS)
-        out = response.json()
-
-        if response.status_code != 200:
-            try:
-                msg = response.json().get('message')
-            except Exception:
-                msg = None
-
-            raise ApiException(
-                response.status_code,
-                msg or "An unspecified error has occurred.")
-        return out
-    except requests.ConnectionError:
-        flash('Error connecting to backend service.', 'danger')

--- a/pmg/helpers.py
+++ b/pmg/helpers.py
@@ -131,7 +131,6 @@ def feedback_form():
 def inject_paths():
     context_vars = {
         'FRONTEND_HOST': app.config['FRONTEND_HOST'],
-        'API_HOST': app.config['API_HOST'],
         'STATIC_HOST': app.config['STATIC_HOST'],
     }
     return context_vars

--- a/pmg/user_management.py
+++ b/pmg/user_management.py
@@ -34,7 +34,7 @@ def email_alerts():
 
         return ''
 
-    committees = load_from_api('committee', return_everything=True)['results']
+    committees = load_from_api('v2/committees', return_everything=True)['results']
     if current_user.is_authenticated():
         subscriptions = set(c.id for c in current_user.committee_alerts)
     else:

--- a/pmg/user_management.py
+++ b/pmg/user_management.py
@@ -1,99 +1,15 @@
-import forms
-import requests
-from requests import ConnectionError
-import json
 import logging
 from ga import ga_event
 from collections import defaultdict
 
-from flask import render_template, request, redirect, session, url_for, abort, flash, jsonify
+from flask import render_template, request, redirect, abort, flash, jsonify
 from flask.ext.security import current_user, login_required
-from flask.ext.security.decorators import anonymous_user_required
 
 from pmg import app, db
-from pmg.api.client import ApiException, load_from_api
+from pmg.api.client import load_from_api
 from pmg.models import Committee, SavedSearch
 
-API_HOST = app.config['API_HOST']
 logger = logging.getLogger(__name__)
-
-
-# chat with backend API
-def user_management_api(endpoint, data=None):
-    query_str = "security/" + endpoint
-    headers = {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-    }
-
-    if endpoint != 'login' and session and session.get('api_key'):
-        headers['Authentication-Token'] = session['api_key']
-
-    try:
-        response = requests.post(API_HOST + query_str, data=data, headers=headers, allow_redirects=False)
-        try:
-            out = response.json()
-            if response.status_code != 200:
-                raise ApiException(response.status_code,
-                                   out.get('message', u"An unspecified error has occurred."))
-
-            if out.get('response', {}).get('errors'):
-                for field, messages in out['response']['errors'].iteritems():
-                    for message in messages:
-                        flash(message, 'danger')
-
-        except ValueError:
-            logger.error("Error interpreting response from API. No JSON object could be decoded")
-            flash(u"Error interpreting response from API.", 'danger')
-            logger.debug(response.text)
-            return
-
-        try:
-            logger.debug(json.dumps(out, indent=4))
-        except Exception:
-            logger.debug("Error logging response from API")
-        return out['response']
-
-    except ConnectionError as e:
-        logger.error("Error connecting to backend service: %s" % e, exc_info=e)
-        flash(u'Error connecting to backend service.', 'danger')
-
-
-@app.route('/user/send-confirmation/', methods=['GET', 'POST'])
-def send_confirmation():
-    """View function which sends confirmation instructions."""
-
-    form = forms.SendConfirmationForm(request.form)
-
-    if form.validate_on_submit():
-        data = {
-            'email': form.email.data,
-        }
-        response = user_management_api('confirm', json.dumps(data))
-
-        # redirect user
-        if response and response.get('user'):
-            flash(
-                u'Your confirmation email has been resent. Please check your inbox.',
-                'success')
-            if request.values.get('next'):
-                return redirect(request.values['next'])
-
-    return render_template(
-        'user_management/send_confirmation.html',
-        send_confirmation_form=form)
-
-
-@app.route('/confirm-email/<confirmation_key>', methods=['GET', ])
-@anonymous_user_required
-def confirm_email(confirmation_key):
-    """View function for confirming an email address."""
-
-    response = user_management_api('confirm/' + confirmation_key)
-
-    if response and not response.get('errors'):
-        flash(u'Thanks. Your email address has been confirmed.', 'success')
-    return redirect(url_for('index'))
 
 
 @app.route('/email-alerts/', methods=['GET', 'POST'])

--- a/pmg/views.py
+++ b/pmg/views.py
@@ -21,7 +21,6 @@ from collections import OrderedDict
 import forms
 import utils
 
-API_HOST = app.config['API_HOST']
 LEGACY_DOMAINS = set(['new.pmg.org.za', 'www.pmg.org.za', 'bills.pmg.org.za', 'www.legacy.pmg.org.za', 'legacy.pmg.org.za'])
 
 app.session = session


### PR DESCRIPTION
The primary advantage here is that it prevents tromboning, where a request from the PMG frontend to the API has to go out through the EC2 firewall then back to the same host it originated from. We bypass this by telling the frontend to access the API at api-internal.pmg.org.za which resolves to the internal IP address of the host.

This will save us about $20 a month in traffic fees, and should make many pages faster, particularly committee detail pages which load a lot of content.

Here's a simple speed comparison (where 172.31.44.51 is the internal IP of the instance).

```
ubuntu@pmg:~$ ping pmg.org.za
PING pmg.org.za (52.19.135.212) 56(84) bytes of data.
64 bytes from ec2-52-19-135-212.eu-west-1.compute.amazonaws.com (52.19.135.212): icmp_seq=1 ttl=63 time=0.393 ms
64 bytes from ec2-52-19-135-212.eu-west-1.compute.amazonaws.com (52.19.135.212): icmp_seq=2 ttl=63 time=0.417 ms
64 bytes from ec2-52-19-135-212.eu-west-1.compute.amazonaws.com (52.19.135.212): icmp_seq=3 ttl=63 time=0.521 ms
^C
--- pmg.org.za ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2001ms
rtt min/avg/max/mdev = 0.393/0.443/0.521/0.060 ms
ubuntu@pmg:~$ ping 172.31.44.51
PING 172.31.44.51 (172.31.44.51) 56(84) bytes of data.
64 bytes from 172.31.44.51: icmp_seq=1 ttl=64 time=0.030 ms
64 bytes from 172.31.44.51: icmp_seq=2 ttl=64 time=0.035 ms
64 bytes from 172.31.44.51: icmp_seq=3 ttl=64 time=0.037 ms
64 bytes from 172.31.44.51: icmp_seq=4 ttl=64 time=0.018 ms
^C
--- 172.31.44.51 ping statistics ---
```

This changes also removes some old, unused references to the API_HOST setting.

@jbothma @smmbll 