### PR TITLE
Simplify megamenu

### DIFF
--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1246,22 +1246,6 @@ li.committee.item.list-megamenu {
   bottom: -3px;
 }
 
-.menu-mobile {
-    display: none;
-    padding: 20px;
-}
-
-.menu-mobile:after {
-    font-size: 2.5rem;
-    padding: 0;
-    float: right;
-    position: relative;
-    top: 50%;
-    -webkit-transform: translateY(-25%);
-    -ms-transform: translateY(-25%);
-    transform: translateY(-25%);
-}
-
 .menu > ul {
     margin: 0 auto 0 -5px;
     width: 100%;
@@ -1272,19 +1256,7 @@ li.committee.item.list-megamenu {
     box-sizing: border-box;
 }
 
-.menu > ul:before,
-.menu > ul:after {
-    content: "";
-    display: table;
-}
-
-.menu > ul:after {
-    clear: both;
-}
-
 .menu > ul > li {
-    float: left;
-    background: #efefef;
     padding: 0;
     margin: 0;
 }
@@ -1339,42 +1311,6 @@ li.committee.item.list-megamenu {
     margin: 10px 0 0;
     list-style: none;
     box-sizing: border-box;
-}
-
-.menu > ul > li > ul > li > ul:before,
-.menu > ul > li > ul > li > ul:after {
-    content: "";
-    display: table;
-}
-
-.menu > ul > li > ul > li > ul:after {
-    clear: both;
-}
-
-.menu > ul > li > ul > li > ul > li {
-    float: left;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-}
-
-.menu > ul > li > ul > li > ul > li a {
-    border: 0;
-}
-
-.menu > ul > li > ul.normal-sub {
-    width: 300px;
-    left: auto;
-    padding: 2px 20px;
-}
-
-.menu > ul > li > ul.normal-sub > li {
-    width: 100%;
-}
-
-.menu > ul > li > ul.normal-sub > li a {
-    border: 0;
-    padding: 1em 0;
 }
 
 .menu > ul > li > a {

--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1246,65 +1246,76 @@ li.committee.item.list-megamenu {
   bottom: -3px;
 }
 
-.menu > ul {
+.menu {
+  & > ul {
     margin: 0 auto 0 -5px;
     width: 100%;
-    list-style: none;
     padding: 0;
     position: relative;
-    /* IF .menu position=relative -> ul = container width, ELSE ul = 100% width */
-    box-sizing: border-box;
-}
+    list-style: none;
 
-.menu {
-  & > ul > li {
+    & > li {
       padding: 0;
       margin: 0;
+      display: inline-block;
+
+      & > a {
+        padding: 10px;
+      }
+    }
   }
 
   .menu-item {
-      display: block;
-  }
-
-  .megamenu {
-      width: 90%;
-      background: #fff;
-      padding: 0;
-      position: absolute;
-      z-index: 99;
-      left: 0;
-      margin: 0;
-      margin-top: -1px;
-      margin-left: -5px;
-      list-style: none;
-      box-sizing: border-box;
-      border: 1px solid #ccc;
-      box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.25);
-  }
-
-  & > ul > li > a {
-    padding: 10px;
+    display: block;
   }
 
   h3 {
     padding-left: 15px;
     margin-top: 10px;
   }
-}
 
-.megamenu-header-follow {
-  width: 30%;
-  background-color: #fff;
-  border-bottom: 1px solid #ccc;
-  border-top-left-radius: 4px;
-}
+  .megamenu {
+    width: 90%;
+    background: #fff;
+    padding: 0;
+    position: absolute;
+    z-index: 99;
+    left: 0;
+    margin: 0;
+    margin-top: -1px;
+    margin-left: -5px;
+    box-sizing: border-box;
+    border: 1px solid #ccc;
+    box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.25);
 
-.megamenu-header-recent {
-  width: 70%;
-  background-color: #fff;
-  border-bottom: 1px solid #ccc;
-  border-top-right-radius: 4px;
+    .megamenu-cta {
+      margin-left: 15px;
+      margin-bottom: 15px;
+    }
 
+    .mm-committees-list, .mm-default-committees-list, .mm-default-meetings-list, .mm-recent-meetings-list {
+      list-style-type: square;
+      padding-inline-start: 30px;
+      margin-bottom: 15px !important;
+    }
+
+    .mm-default-meetings-list, .mm-recent-meetings-list {
+      padding-right: 15px;
+    }
+
+    .mm-committees-list, .mm-default-committees-list {
+      padding-right: 0;
+    }
+
+    .mm-default-committees, .mm-committees {
+      padding-right: 0;
+    }
+
+    .mm-default-meetings, .mm-recent-meetings {
+      padding-left: 0;
+      border-left: 1px solid #ccc;
+    }
+  }
 }
 
 .navbar-form .input-group .input-group-btn {
@@ -1313,20 +1324,6 @@ li.committee.item.list-megamenu {
 
 .cte-follow-committee {
   display:inline-block;
-}
-
-.committee-megamenu-table tr {
-  font-size: 14px;
-}
-
-.committee-megamenu-table, cte-recent-meetings-table {
-  padding-left: 20px;
-}
-
-@media (max-width: 1199px) {
-  .menu > ul > li > ul {
-    width: 100%;
-  }
 }
 
 .committees-menulink {
@@ -1342,41 +1339,6 @@ li.committee.item.list-megamenu {
     border: 1px solid #ccc;
     border-width: 0px 1px;
   }
-}
-
-.megamenu-cts-col {
-  border-right: 1px solid #ccc;
-}
-
-.megamenu-cta {
-  margin-left: 15px;
-  margin-bottom: 15px;
-}
-
-.mm-committees-list, .mm-default-committees-list, .mm-default-meetings-list, .mm-recent-meetings-list {
-  padding-inline-start: 30px;
-  margin-bottom: 15px !important;
-}
-
-.mm-default-meetings-list, .mm-recent-meetings-list {
-  padding-right: 15px;
-}
-
-.btn-megamenu-inline {
-  display: inline !important;
-}
-
-.mm-committees-list, .mm-default-committees-list {
-  padding-right: 0;
-}
-
-.mm-default-committees, .mm-committees {
-  padding-right: 0;
-}
-
-.mm-default-meetings, .mm-recent-meetings {
-  padding-left: 0;
-  border-left: 1px solid #ccc;
 }
 
 .mobile-menu-li {

--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1256,65 +1256,40 @@ li.committee.item.list-megamenu {
     box-sizing: border-box;
 }
 
-.menu > ul > li {
-    padding: 0;
-    margin: 0;
-}
+.menu {
+  & > ul > li {
+      padding: 0;
+      margin: 0;
+  }
 
-.menu-item {
-    display: block;
-}
+  .menu-item {
+      display: block;
+  }
 
-.menu > ul > li > ul {
-    width: 90%;
-    background: #fff;
-    padding: 0;
-    position: absolute;
-    z-index: 99;
-    left: 0;
-    margin: 0;
-    margin-top: -1px;
-    margin-left: -5px;
-    list-style: none;
-    box-sizing: border-box;
-    border: 1px solid #ccc;
-    box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.25);
-}
+  .megamenu {
+      width: 90%;
+      background: #fff;
+      padding: 0;
+      position: absolute;
+      z-index: 99;
+      left: 0;
+      margin: 0;
+      margin-top: -1px;
+      margin-left: -5px;
+      list-style: none;
+      box-sizing: border-box;
+      border: 1px solid #ccc;
+      box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.25);
+  }
 
-.menu > ul > li > ul:before,
-.menu > ul > li > ul:after {
-    content: "";
-    display: table;
-}
+  & > ul > li > a {
+    padding: 10px;
+  }
 
-.menu > ul > li > ul:after {
-    clear: both;
-}
-
-.menu > ul > li > ul > li {
-    margin: 0;
-    padding-bottom: 0;
-    list-style: none;
-    float: left;
-}
-
-.menu > ul > li > ul > li a {
-    padding: .2em 0;
-    width: 95%;
-    display: block;
-    border-bottom: 1px solid #ccc;
-}
-
-.menu > ul > li > ul > li > ul {
-    display: block;
-    padding: 0;
-    margin: 10px 0 0;
-    list-style: none;
-    box-sizing: border-box;
-}
-
-.menu > ul > li > a {
-  padding: 10px;
+  h3 {
+    padding-left: 15px;
+    margin-top: 10px;
+  }
 }
 
 .megamenu-header-follow {
@@ -1330,15 +1305,6 @@ li.committee.item.list-megamenu {
   border-bottom: 1px solid #ccc;
   border-top-right-radius: 4px;
 
-}
-
-.megamenu-td {
-  padding: 8px;
-}
-
-.megamenu-h3 {
-  padding-left: 15px;
-  margin-top: 10px;
 }
 
 .navbar-form .input-group .input-group-btn {

--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1246,11 +1246,6 @@ li.committee.item.list-megamenu {
   bottom: -3px;
 }
 
-.menu-container {
-  margin: 0 auto;
-  background: #efefef;
-}
-
 .menu-mobile {
     display: none;
     padding: 20px;
@@ -1391,9 +1386,6 @@ li.committee.item.list-megamenu {
 }
 
 @media only screen and (max-width: 767px) {
-    .menu-container {
-        width: 100%;
-    }
     .menu-mobile {
         display: block;
     }

--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1276,7 +1276,7 @@ li.committee.item.list-megamenu {
 }
 
 .menu > ul {
-    margin: 0 auto;
+    margin: 0 auto 0 -5px;
     width: 100%;
     list-style: none;
     padding: 0;

--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1246,27 +1246,22 @@ li.committee.item.list-megamenu {
   bottom: -3px;
 }
 
-.menu {
-  & > ul {
-    margin: 0 auto 0 -5px;
-    width: 100%;
+ul.menu {
+  margin: 0 auto 0 -5px;
+  width: 100%;
+  padding: 0;
+  position: relative;
+  list-style: none;
+
+  & > li {
     padding: 0;
-    position: relative;
-    list-style: none;
+    margin: 0;
+    display: inline-block;
 
-    & > li {
-      padding: 0;
-      margin: 0;
-      display: inline-block;
-
-      & > a {
-        padding: 10px;
-      }
+    & > a {
+      padding: 10px;
+      display: block;
     }
-  }
-
-  .menu-item {
-    display: block;
   }
 
   h3 {

--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1262,14 +1262,6 @@ li.committee.item.list-megamenu {
     transform: translateY(-25%);
 }
 
-.menu-dropdown-icon:before {
-    display: none;
-    cursor: pointer;
-    float: right;
-    background: #fff;
-    color: #333;
-}
-
 .menu > ul {
     margin: 0 auto 0 -5px;
     width: 100%;
@@ -1383,51 +1375,6 @@ li.committee.item.list-megamenu {
 .menu > ul > li > ul.normal-sub > li a {
     border: 0;
     padding: 1em 0;
-}
-
-@media only screen and (max-width: 767px) {
-    .menu-mobile {
-        display: block;
-    }
-    .menu-dropdown-icon:before {
-        display: block;
-    }
-    .menu > ul {
-        display: none;
-    }
-    .menu > ul > li {
-        width: 100%;
-        float: none;
-        display: block;
-    }
-    .menu > ul > li a {
-        padding: 1.5em;
-        width: 100%;
-        display: block;
-    }
-    .menu > ul > li > ul {
-        position: relative;
-    }
-    .menu > ul > li > ul.normal-sub {
-        width: 100%;
-    }
-    .menu > ul > li > ul > li {
-        float: none;
-        width: 100%;
-        margin-top: 20px;
-    }
-    .menu > ul > li > ul > li:first-child {
-        margin: 0;
-    }
-    .menu > ul > li > ul > li > ul {
-        position: relative;
-    }
-    .menu > ul > li > ul > li > ul > li {
-        float: none;
-    }
-    .menu .show-on-mobile {
-        display: block;
-    }
 }
 
 .menu > ul > li > a {

--- a/pmg/static/resources/javascript/megamenu.js
+++ b/pmg/static/resources/javascript/megamenu.js
@@ -3,24 +3,6 @@ $(document).ready(function () {
 
     "use strict";
 
-
-    $('.menu > ul > li > ul:not(:has(ul))').addClass('normal-sub');
-    //Checks if drodown menu's li elements have anothere level (ul), if not the dropdown is shown as regular dropdown, not a mega menu (thanks Luka Kladaric)
-
-    $(".menu > ul").before("<a href=\"#\" class=\"menu-mobile\">Navigation</a>");
-
-    //Adds menu-mobile class (for mobile toggle menu) before the normal menu
-    //Mobile menu is hidden if width is more then 959px, but normal menu is displayed
-    //Normal menu is hidden if width is below 959px, and jquery adds mobile menu
-    //Done this way so it can be used with wordpress without any trouble
-
-    $(".menu-mobile").click(function (e) {
-        $(".menu > ul").toggleClass('show-on-mobile');
-        e.preventDefault();
-    });
-    //when clicked on mobile-menu, normal menu is shown as a list, classic rwd menu story (thanks mwl from stackoverflow)
-
-
     $(".megamenu").mouseenter(function() {
       $(".committees-menulink").addClass("committees-menulink-hover");
       $(".megamenu").show();

--- a/pmg/static/resources/javascript/megamenu.js
+++ b/pmg/static/resources/javascript/megamenu.js
@@ -3,9 +3,6 @@ $(document).ready(function () {
 
     "use strict";
 
-    $('.menu > ul > li:has( > ul)').addClass('menu-dropdown-icon');
-    //Checks if li has sub (ul) and adds class for toggle icon - just an UI
-
 
     $('.menu > ul > li > ul:not(:has(ul))').addClass('normal-sub');
     //Checks if drodown menu's li elements have anothere level (ul), if not the dropdown is shown as regular dropdown, not a mega menu (thanks Luka Kladaric)

--- a/pmg/templates/_header.html
+++ b/pmg/templates/_header.html
@@ -123,11 +123,9 @@
         <i class="fa fa-facebook"></i> Facebook
       </a>
     </div>
-    <ul class="list-inline">
-      <div class="menu-container hidden-xs top-links">
-        {% include "_top_links.html" %}
-      </div>
-    </ul>
+    <div class="menu-container hidden-xs top-links">
+      {% include "_top_links.html" %}
+    </div>
   </div>
 </nav>
 {% endblock %}

--- a/pmg/templates/_header.html
+++ b/pmg/templates/_header.html
@@ -123,9 +123,7 @@
         <i class="fa fa-facebook"></i> Facebook
       </a>
     </div>
-    <div class="menu-container hidden-xs top-links">
-      {% include "_top_links.html" %}
-    </div>
+    {% include "_top_links.html" %}
   </div>
 </nav>
 {% endblock %}

--- a/pmg/templates/_megamenu.html
+++ b/pmg/templates/_megamenu.html
@@ -4,7 +4,7 @@
   {% else %}
   <div class="col-xs-5 mm-committees">
   {% endif %}
-    <h3 class="megamenu-h3">Committees you follow</h3>
+    <h3>Committees you follow</h3>
     <ul class="mm-committees-list">
       {% for committee in user_following %}
       <li data-id="{{ committee.id }}" data-follow-list="true">
@@ -19,7 +19,7 @@
   {% else %}
   <div class="col-xs-7 mm-recent-meetings">
   {% endif %}
-    <h3 class="megamenu-h3">Latest meetings of your commitees</h3>
+    <h3>Latest meetings of your commitees</h3>
     <ul class="mm-recent-meetings-list">
       {% for meeting in recent_meetings %}
       <li data-id="{{ meeting.committee_id }}" data-follow-list="true">
@@ -34,7 +34,7 @@
   {% else %}
   <div class="col-xs-5 mm-default-committees hidden">
   {% endif %}
-    <h3 class="megamenu-h3">Popular committees</h3>
+    <h3>Popular committees</h3>
     <ul class="mm-default-committees-list">
     {% for committee in default_committees %}
     <li>
@@ -53,7 +53,7 @@
   {% else %}
   <div class="col-xs-7 mm-default-meetings hidden">
   {% endif %}
-    <h3 class="megamenu-h3">Recent meetings</h3>
+    <h3>Recent meetings</h3>
     <ul class="mm-default-meetings-list">
     {% for meeting in default_meetings %}
       <li>

--- a/pmg/templates/_top_links.html
+++ b/pmg/templates/_top_links.html
@@ -1,14 +1,12 @@
-<div class="menu">
-  <ul>
-    <li>
-      <a class="committees-menulink menu-item" href="/committees/">Committees and Meetings</a>
-      <div class="megamenu" style="display: none">
-	{% include '_megamenu.html' %}
-      </div>
-    </li>
-    <li><a class="menu-item" href="/members">MPs</a></li>
-    <li><a class="menu-item" href="/bills">Bills</a></li>
-    <li><a class="menu-item" href="/question_replies">Questions and Replies</a></li>
-    <li><a class="menu-item" href="/calls-for-comments">Calls for Comments</a></li>
-  </ul>
-</div>
+<ul class="menu">
+  <li>
+    <a class="committees-menulink menu-item" href="/committees/">Committees and Meetings</a>
+    <div class="megamenu" style="display: none">
+      {% include '_megamenu.html' %}
+    </div>
+  </li>
+  <li><a href="/members">MPs</a></li>
+  <li><a href="/bills">Bills</a></li>
+  <li><a href="/question_replies">Questions and Replies</a></li>
+  <li><a href="/calls-for-comments">Calls for Comments</a></li>
+</ul>

--- a/pmg/templates/_top_links.html
+++ b/pmg/templates/_top_links.html
@@ -1,10 +1,10 @@
 <div class="menu">
-  <ul class="list-inline">
+  <ul>
     <li>
       <a class="committees-menulink menu-item" href="/committees/">Committees and Meetings</a>
-      <ul class="megamenu" style="display: none">
+      <div class="megamenu" style="display: none">
 	{% include '_megamenu.html' %}
-      </ul>
+      </div>
     </li>
     <li><a class="menu-item" href="/members">MPs</a></li>
     <li><a class="menu-item" href="/bills">Bills</a></li>

--- a/pmg/templates/_top_links.html
+++ b/pmg/templates/_top_links.html
@@ -1,12 +1,14 @@
 <div class="menu">
-  <ul>
-		<li>
+  <ul class="list-inline">
+    <li>
       <a class="committees-menulink menu-item" href="/committees/">Committees and Meetings</a>
       <ul class="hidden-xs megamenu" style="display: none">
-  			{% include '_megamenu.html' %}
+	{% include '_megamenu.html' %}
       </ul>
-      <li><a class="menu-item" href="/members">MPs</a></li>
-      <li><a class="menu-item" href="/bills">Bills</a></li>
-      <li><a class="menu-item" href="/question_replies">Questions and Replies</a></li>
-      <li><a class="menu-item" href="/calls-for-comments">Calls for Comments</a></li>
+    </li>
+    <li><a class="menu-item" href="/members">MPs</a></li>
+    <li><a class="menu-item" href="/bills">Bills</a></li>
+    <li><a class="menu-item" href="/question_replies">Questions and Replies</a></li>
+    <li><a class="menu-item" href="/calls-for-comments">Calls for Comments</a></li>
+  </ul>
 </div>

--- a/pmg/templates/_top_links.html
+++ b/pmg/templates/_top_links.html
@@ -2,7 +2,7 @@
   <ul class="list-inline">
     <li>
       <a class="committees-menulink menu-item" href="/committees/">Committees and Meetings</a>
-      <ul class="hidden-xs megamenu" style="display: none">
+      <ul class="megamenu" style="display: none">
 	{% include '_megamenu.html' %}
       </ul>
     </li>


### PR DESCRIPTION
* remove unnecessary megamenu styles and code that we weren't using
* nest megamenu css since we're using SCSS and it makes it much easier to understand what's going on
* style elements like `h3` inside the megamenu by just styling `.megamenu h3` rather than having to add specific classes to each `h3` element
* remove support for mobile since we don't use it
* make the html valid (only permitted child of `ul` is `li`)

@guushoekman 