### PR TITLE
Make meetings in megamenu easier to read

### DIFF
--- a/pmg/static/resources/css/style.scss
+++ b/pmg/static/resources/css/style.scss
@@ -1288,27 +1288,40 @@ ul.menu {
       margin-bottom: 15px;
     }
 
-    .mm-committees-list, .mm-default-committees-list, .mm-default-meetings-list, .mm-recent-meetings-list {
+    .mm-committees-list, .mm-recent-meetings-list {
       list-style-type: square;
       padding-inline-start: 30px;
       margin-bottom: 15px !important;
     }
 
-    .mm-default-meetings-list, .mm-recent-meetings-list {
+    .mm-recent-meetings-list {
       padding-right: 15px;
+      line-height: 1.3;
+
+      li {
+        margin-bottom: 5px;
+      }
     }
 
-    .mm-committees-list, .mm-default-committees-list {
+    .mm-committees-list {
       padding-right: 0;
     }
 
-    .mm-default-committees, .mm-committees {
+    .mm-committees {
       padding-right: 0;
     }
 
-    .mm-default-meetings, .mm-recent-meetings {
+    .mm-recent-meetings {
       padding-left: 0;
       border-left: 1px solid #ccc;
+
+      a {
+        margin-right: 5px;
+      }
+
+      small {
+        color: #777;
+      }
     }
   }
 }

--- a/pmg/templates/_megamenu.html
+++ b/pmg/templates/_megamenu.html
@@ -35,7 +35,13 @@
     <ul class="mm-recent-meetings-list">
       {% for meeting in recent_meetings %}
       <li data-id="{{ meeting.committee_id }}" data-follow-list="true">
-        <a href="{{ url_for('committee_meeting', event_id=meeting.id, via='cte-menu') }}">{{ meeting.title }}</a><small> | <a href="{{ url_for('committee_detail', committee_id=meeting.committee.id, via='cte-menu') }}">{{ meeting.committee.name }}</a> | {{ meeting.date | pretty_date }}</small>
+        <a href="{{ url_for('committee_meeting', event_id=meeting.id, via='cte-menu') }}">{{ meeting.title }}</a>
+        <small>
+          {{ meeting.committee.name }}
+          {% if meeting.committee.premium %}<span class="premium"> <i class="fa fa-key"></i></span>{% endif %}
+          •
+          {{ meeting.date | pretty_date }}
+        </small>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
- Spacing between items wider than line heights
- Fewer links
- Color in addition to the smaller font size
- indicate premium in meeting links